### PR TITLE
Adding travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - '3.6'
+  - '3.9'
 sudo: required
 install:
   - python3 -m venv env

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
       cat nohup.out; 
       exit 1; 
     else 
-      echo "Streamlit server running"
+      echo "Streamlit server running";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 script:
   # Staring streamlit in the background:
   - nohup streamlit run app.py &
+  - sleep 10 
 
   # Checking if streamlit is running:
   - if [[ ! $(ps aux | grep streamlit | grep -v grep) ]]; then 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+  - '3.6'
+sudo: required
+install:
+  - python3 -m venv env
+  - source env/bin/activate
+  - python3 -m pip install -r requirements.txt
+script:
+  # Staring streamlit in the background:
+  - nohup streamlit run app.py &
+
+  # Checking if streamlit is running:
+  - if [[ ! $(ps aux | grep streamlit | grep -v grep) ]]; then 
+      echo "Launcing streamlit server failed."; 
+      cat nohup.out; 
+      exit 1; 
+    else 
+      echo "Streamlit server running"
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 
   # Checking if streamlit is running:
   - if [[ ! $(ps aux | grep streamlit | grep -v grep) ]]; then 
-      echo "Launcing streamlit server failed."; 
+      echo "Streamlit server launch failed."; 
       cat nohup.out; 
       exit 1; 
     else 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ plotly-express==0.4.1
 psutil==5.8.0
 pyspark==3.2.0
 streamlit==1.5.1
-click==8.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ plotly-express==0.4.1
 psutil==5.8.0
 pyspark==3.2.0
 streamlit==1.5.1
-click==8
+click==8.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ plotly-express==0.4.1
 psutil==5.8.0
 pyspark==3.2.0
 streamlit==1.5.1
+click==8


### PR DESCRIPTION
To avoid surprises, travis integration can tell if the server can be run or not. 

* The deployment plan builds the environment.
* Start up the webserver in the background.
* Waits 10s.
* Then checks if the server is still running. This time allows the server to completely start up.
* If the server fails, the output is displayed on the travis report, and the build fails.

This update is not essential.