### PR TITLE
Add nullified score metrics and change order of run selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,13 +105,13 @@ if page == "Compare metrics":
     select_runs = st.sidebar.multiselect(
         "Select two datasets:",
         sorted(data.runId.unique(), reverse=True),
-        help="First indicate the run with which you wish to make the comparison.",
+        help="First indicate the latest run and secondly the run with which you wish to make the comparison.",
     )
 
     # Apply masks
     if len(select_runs) == 2:
-        previous_run = select_runs[0]
-        latest_run = select_runs[1]
+        latest_run = select_runs[0]
+        previous_run = select_runs[1]
         masks_run = (data["runId"] == previous_run) | (data["runId"] == latest_run)
         data = data[masks_run]
 

--- a/metrics.py
+++ b/metrics.py
@@ -373,6 +373,9 @@ def main(args):
             # Evidence count (duplicates).
             document_total_count(evidence_failed.filter(f.col('markedDuplicate')),
                                  'evidenceDuplicateTotalCount'),
+            # Evidence count (nullified score).
+            document_total_count(evidence_failed.filter(f.col('nullifiedScore')),
+                                 'evidenceNullifiedScoreTotalCount'),
             # Evidence count (targets not resolved).
             document_total_count(evidence_failed.filter(~f.col('resolvedTarget')),
                                  'evidenceUnresolvedTargetTotalCount'),
@@ -380,7 +383,7 @@ def main(args):
             document_total_count(evidence_failed.filter(~f.col('resolvedDisease')),
                                  'evidenceUnresolvedDiseaseTotalCount'),
 
-            # Evidence count by datasource (invalids).
+            # Total invalids by datasource.
             document_count_by(evidence_failed,
                               'datasourceId',
                               'evidenceInvalidCountByDatasource'),
@@ -388,6 +391,10 @@ def main(args):
             document_count_by(evidence_failed.filter(f.col('markedDuplicate')),
                               'datasourceId',
                               'evidenceDuplicateCountByDatasource'),
+            # Evidence count by datasource (nullified score).
+            document_count_by(evidence_failed.filter(f.col('nullifiedScore')),
+                                'datasourceId',
+                                'evidenceNullifiedScoreCountByDatasource'),
             # Evidence count by datasource (targets not resolved).
             document_count_by(evidence_failed.filter(~f.col('resolvedTarget')),
                               'datasourceId',
@@ -397,12 +404,15 @@ def main(args):
                               'datasourceId',
                               'evidenceUnresolvedDiseaseCountByDatasource'),
 
-            # Distinct values in selected fields (invalid evidence).
+            # Distinct values in selected fields (total invalid evidence).
             evidence_distinct_fields_count(evidence_failed.select(columns_to_report),
                                            'evidenceInvalidDistinctFieldsCountByDatasource'),
             # Evidence count by datasource (duplicates).
             evidence_distinct_fields_count(evidence_failed.filter(f.col('markedDuplicate')).select(columns_to_report),
                                            'evidenceDuplicateDistinctFieldsCountByDatasource'),
+            # Evidence count by datasource (nullified score).
+            evidence_distinct_fields_count(evidence_failed.filter(f.col('nullifiedScore')).select(columns_to_report),
+                                             'evidenceNullifiedScoreDistinctFieldsCountByDatasource'),
             # Evidence count by datasource (targets not resolved).
             evidence_distinct_fields_count(evidence_failed.filter(~f.col('resolvedTarget')).select(columns_to_report),
                                            'evidenceUnresolvedTargetDistinctFieldsCountByDatasource'),


### PR DESCRIPTION
This PR:
- Closes #2638: metrics on the invalid evidence because of a null score are added
- Changes the order in which the runs are selected to be compared. Now you first select the most recent run first.