### PR TITLE
feat: add `delete release metrics` button to the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 env/**
 outputs/**/*
 code_bundle.zip
+.streamlit/secrets.toml

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from PIL import Image
 import streamlit as st
 
 from src.metric_visualisation.utils import (
+    _delete_release_metrics,
     show_table,
     load_data,
     plot_enrichment,
@@ -139,12 +140,27 @@ def main(cfg: DictConfig):
 
             # Display table
             st.dataframe(output.style.format(precision=2))
-            st.download_button(
-                label="Download data as CSV",
-                data=output.to_csv().encode("utf-8"),
-                file_name=f"metrics-{select_run}.csv",
-                mime="text/csv",
-            )
+            download_button, delete_button = st.columns(2)
+            with download_button:
+                st.download_button(
+                    label="Download data as CSV",
+                    data=output.to_csv().encode("utf-8"),
+                    file_name=f"metrics-{select_run}.csv",
+                    mime="text/csv",
+                )
+            with delete_button:
+                if st.button(
+                    "Delete release metrics",
+                    help="Delete release metrics from the GCS bucket. This action is irreversible.",
+                ):
+                    gcs_data_path = f"{cfg.metric_calculation.data_repositories.metrics_root}/{select_run}.csv"
+                    st.text_input(
+                        "Type password to confirm",
+                        placeholder="OT manager password",
+                        key="password_input",
+                        on_change=_delete_release_metrics,
+                        args=(gcs_data_path,),
+                    )
 
     if page == "Compare metrics":
         # Select two datasets to compare

--- a/docs/metric-visualisation.md
+++ b/docs/metric-visualisation.md
@@ -21,6 +21,14 @@ In order to do that:
 2. In the upper right corner, click on your username and switch to the _opentargets_ workspace.
 3. Next to the _ot-release-metrics_ app, click on a three dot icon and then choose “Reboot”.
 
-
 > **Note**
 > A “Rerun” option, available inside the app itself from a sandwich dropdown menu in the upper right corner, is _different_ to the “Reboot” option described above, and will not work to make the app ingest the new data.
+
+## Deleting a metrics run file from the app
+If a metrics run file is no longer needed, it can be deleted from the app. In order to do that:
+1. Go to the Explore tab and select the file to be deleted.
+2. Click on the "Delete release metrics" button.
+3. Confirm the deletion by providing the password in the pop-up window. This password can be found in the app secrets in Streamlit Cloud or in the or in the Open Targets central login spreadsheet.
+
+!!! warning
+    This will delete data stored in Google Cloud Storage, and it cannot be undone.

--- a/src/metric_visualisation/utils.py
+++ b/src/metric_visualisation/utils.py
@@ -5,6 +5,7 @@ import gcsfs
 import pandas as pd
 import plotly.express as px
 import streamlit as st
+from gcsfs import GCSFileSystem
 
 
 def show_table(
@@ -251,3 +252,20 @@ def compare_entity(
         )
 
     return df
+
+
+def _delete_release_metrics(file_path: str):
+    """Deletes the metrics of the release from GCS if the password matchs up."""
+    password_input = st.session_state.password_input
+    c = st.container(border=True)
+    c.write(f"You entered: {password_input}")
+    if password_input != st.secrets["MANAGER_PASSWORD"]:
+        c.error("Incorrect password")
+    else:
+        c.write("Correct password. Deleting...")
+        try:
+            gcs = GCSFileSystem()
+            gcs.rm(file_path)
+            c.write("Metrics deleted successfully")
+        except Exception as e:
+            c.error(f"Error deleting metrics: {e}")


### PR DESCRIPTION
This PR includes the addition to the `Explore metrics` tab to delete the metrics file for a specific run.
My premise is that having 4 metric files for one release is not particularly relevant after the release process is done so making them available makes the usage of the app messier. The idea behind this proposed solution is to delete metric files that have become obsolete through the UI, without having to programatically interact with the data in the buckets.

To delete the data, you need to pass a password to make sure noone external messes up with our data. For that, I've set up app secrets following [their recommendations](https://docs.streamlit.io/library/advanced-features/secrets-management). To test this locally, you need to store the environment variable inside `.streamlit/secrets.yaml` file (gitignored).
The password is stored in the central login spreadsheet, and can be edited in https://share.streamlit.io/
![image](https://github.com/opentargets/ot-release-metrics/assets/45119610/c69140ba-ab8d-4848-9478-11d3b915c642)

