### PR TITLE
feat: use huggingface as a public hub to store Platform metrics

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,8 +29,7 @@ metric_calculation:
     efo_mappings: ${metric_calculation.data_repositories.metrics_root}/gold-standard/mesh_mappings.tsv
 
   outputs:
-    # Metrics are written to the directory that contains them all.
-    all_metrics_path_base: ${metric_calculation.data_repositories.metrics_root}
+    hf_repo_id: opentargets/ot-release-metrics
     release_output_path: ${metric_calculation.data_repositories.metadata_output_root}/metrics.csv
 
 metric_visualization:

--- a/metric-calculation/requirements.txt
+++ b/metric-calculation/requirements.txt
@@ -1,6 +1,9 @@
+datasets>=2.21.0
 gcsfs>=2022.7.1
 hydra-core>=1.3.0
 pandas>=1.3.4
 protobuf>=3.20.0
 pyspark>=3.2.0
 furl==2.1.3
+psutil>=5.8.0
+urllib3==1.26.6

--- a/metric-calculation/requirements.txt
+++ b/metric-calculation/requirements.txt
@@ -1,6 +1,8 @@
 datasets>=2.21.0
 gcsfs>=2022.7.1
+google-cloud-secret-manager>=2.20.0
 hydra-core>=1.3.0
+huggingface-hub>=0.24.5
 pandas>=1.3.4
 protobuf>=3.20.0
 pyspark>=3.2.0

--- a/metric-calculation/src/metric_calculation/metrics.py
+++ b/metric-calculation/src/metric_calculation/metrics.py
@@ -17,6 +17,7 @@ import pyspark.sql.functions as f
 import pyspark.sql.types as t
 
 from src.metric_calculation.utils import (
+    access_gcp_secret,
     initialize_spark_session,
     read_path_if_provided,
     fetch_pre_etl_evidence,
@@ -612,6 +613,7 @@ def main(cfg: DictConfig) -> None:
         metrics,
         file_output_name=f"{run_id}.csv",
         repo_id=cfg.outputs.hf_repo_id,
+        hf_token=access_gcp_secret("hfhub-key", "open-targets-eu-dev")
     )
     logging.info(f"Metrics {run_id}.csv have been uploaded to HG Hub app: {cfg.outputs.hf_repo_id}")
 

--- a/metric-calculation/src/metric_calculation/metrics.py
+++ b/metric-calculation/src/metric_calculation/metrics.py
@@ -19,9 +19,10 @@ import pyspark.sql.types as t
 from src.metric_calculation.utils import (
     initialize_spark_session,
     read_path_if_provided,
-    write_metrics_to_csv,
     fetch_pre_etl_evidence,
     detect_release_timestamp,
+    write_metrics_to_csv,
+    write_metrics_to_hf_hub
 )
 
 if TYPE_CHECKING:
@@ -607,9 +608,12 @@ def main(cfg: DictConfig) -> None:
     metrics = reduce(DataFrame.unionByName, datasets)
     metrics = metrics.withColumn("runId", f.lit(run_id)).cache()
 
-    app_metrics_path = f"{cfg.outputs.all_metrics_path_base}/{run_id}.csv"
-    write_metrics_to_csv(metrics, app_metrics_path)
-    logging.info(f"Wrote metrics to the visualisation app path: {app_metrics_path}")
+    write_metrics_to_hf_hub(
+        metrics,
+        file_output_name=f"{run_id}.csv",
+        repo_id=cfg.outputs.hf_repo_id,
+    )
+    logging.info(f"Metrics {run_id}.csv have been uploaded to HG Hub app: {cfg.outputs.hf_repo_id}")
 
     if not ot_release.endswith("_pre"):
         write_metrics_to_csv(metrics, cfg.outputs.release_output_path)

--- a/metric-calculation/src/metric_calculation/utils.py
+++ b/metric-calculation/src/metric_calculation/utils.py
@@ -6,6 +6,7 @@ import yaml
 from addict import Dict
 from datasets import Dataset
 import gcsfs
+from huggingface_hub import login
 from pyspark.sql import SparkSession
 import pyspark.sql.functions as f
 
@@ -15,6 +16,22 @@ from modules.common.GoogleBucketResource import GoogleBucketResource
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame
 
+def access_gcp_secret(secret_id: str, project_id: str) -> str:
+    """Access GCP secret manager to get the secret value.
+
+    Args:
+        secret_id (str): ID of the secret
+        project_id (str): ID of the GCP project
+
+    Returns:
+        str: secret value
+    """
+    from google.cloud import secretmanager
+
+    client = secretmanager.SecretManagerServiceClient()
+    name = f"projects/{project_id}/secrets/{secret_id}/versions/latest"
+    response = client.access_secret_version(name=name)
+    return response.payload.data.decode("UTF-8")
 
 def initialize_spark_session():
     """Creates and returns a SparkSession object."""
@@ -78,8 +95,7 @@ def detect_release_timestamp(evidence_metadata_path):
     update_timestamp = parquet_rows[
         0
     ].timeStamp  # Example format: "2023-10-31T18:11:57.508Z".
-    update_date = update_timestamp[:10]  # Example format: "2023-10-31".
-    return update_date
+    return update_timestamp[:10]  # Example format: "2023-10-31".
 
 
 def fetch_pre_etl_evidence():
@@ -111,9 +127,12 @@ def write_metrics_to_hf_hub(
     file_output_name: str,
     repo_id: str = "opentargets/ot-release-metrics",
     data_dir: str = "metrics",
+    hf_token : str | None = None,
 ) -> None:
     """Upload dataset of metrics to HuggingFace Hub."""
     assert file_output_name.endswith(".csv"), "Only CSV files are supported."
+    if hf_token:
+        login(hf_token)
     hf_path = f"hf://datasets/{repo_id}/{data_dir}/{file_output_name}"
     ds = Dataset.from_pandas(metrics_df.toPandas())
     ds.to_csv(hf_path)

--- a/metric-calculation/src/metric_calculation/utils.py
+++ b/metric-calculation/src/metric_calculation/utils.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 import yaml
 
 from addict import Dict
+from datasets import Dataset
 import gcsfs
 from pyspark.sql import SparkSession
 import pyspark.sql.functions as f
@@ -104,3 +105,15 @@ def fetch_pre_etl_evidence():
 
     # Read all files into Spark.
     return SparkSession.getActiveSession().read.json(all_files)
+
+def write_metrics_to_hf_hub(
+    metrics_df: DataFrame,
+    file_output_name: str,
+    repo_id: str = "opentargets/ot-release-metrics",
+    data_dir: str = "metrics",
+) -> None:
+    """Upload dataset of metrics to HuggingFace Hub."""
+    assert file_output_name.endswith(".csv"), "Only CSV files are supported."
+    hf_path = f"hf://datasets/{repo_id}/{data_dir}/{file_output_name}"
+    ds = Dataset.from_pandas(metrics_df.toPandas())
+    ds.to_csv(hf_path)

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -9,7 +9,7 @@ import streamlit as st
 from src.utils import (
     extract_primary_run_id_list,
     show_table,
-    load_data,
+    load_data_from_hf,
     plot_enrichment,
     compare_entity,
     select_and_mask_data_to_compare,
@@ -49,7 +49,7 @@ def main(cfg: DictConfig):
             "allows you to compare the main metrics between two releases."
         ),
     )
-    data = load_data(cfg.metric_calculation.data_repositories.metrics_root)
+    data = load_data_from_hf()
     all_runs = list(data.runId.unique())
     all_releases = extract_primary_run_id_list(all_runs)
 

--- a/streamlit-app/requirements.txt
+++ b/streamlit-app/requirements.txt
@@ -1,6 +1,7 @@
 altair>=4.1.0
 gcsfs>=2022.7.1
 hydra-core>=1.3.0
+huggingface-hub>=0.24.5
 pandas>=1.3.4
 plotly-express>=0.4.1
 streamlit>=1.28.1


### PR DESCRIPTION
The metrics app is failing to load metrics stored in public buckets:
```
[2024-08-18 18:01:52,010][gcsfs][ERROR] - _request out of retries on exception: Failed to retrieve http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/?recursive=true from the Google Compute Engine metadata service. Compute Engine Metadata server unavailable
```

To avoid credential issues, I've created a new `Dataset` in HuggingFace to store our metrics. https://huggingface.co/datasets/opentargets/ot-release-metrics

## New changes
This PR includes:
- Migration of the metrics repository from GCS to HuggingFace. I've uploaded the contents of `gs://ot-release-metrics` to HF's Dataset using HF utils
- Streamlit app feature: fetch metrics files from the HF repository thanks to Pandas native ability to read `hf://` paths
- Metrics calculation feature: upload the metrics to HF using the `datasets` library. This requires passing the HF access token, which is fetched from the Secrets Manager API
- Updates to both Docker images in the registry

It now works locally. Testing on Streamlit's deployment is pending
![image](https://github.com/user-attachments/assets/faf97fbe-8e2f-4e68-a015-047f2f1fa895)

