### PR TITLE
ci: action to build and push docker images to gcp

### DIFF
--- a/.github/workflows/artifact.yaml
+++ b/.github/workflows/artifact.yaml
@@ -1,0 +1,52 @@
+name: Build and Push Docker Images to Artifact Registry
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+env:
+  PROJECT_ID: open-targets-eu-dev
+  REGION: europe-west1
+  GAR_LOCATION: europe-west1-docker.pkg.dev/open-targets-eu-dev/ot-release-metrics
+
+jobs:
+  build-push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+
+      - name: Configure Docker for Google Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Set up QEMU for Multi-Architecture Builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push Metric Calculation Image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.GAR_LOCATION }}/metric-calculation:latest
+          context: .
+          file: metric-calculation/Dockerfile
+
+      - name: Build and Push Streamlit App Image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.GAR_LOCATION }}/app:latest
+          context: .
+          file: streamlit-app/Dockerfile

--- a/metric-calculation/Dockerfile
+++ b/metric-calculation/Dockerfile
@@ -1,6 +1,6 @@
 # Part 1: Common set up. This can be eventually separated into a shared base Open Targets image.
 
-FROM python:3.10
+FROM python:3.12-bullseye
 
 # Suppress interactive prompts.
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This PR automates the generation and of Docker images for both apps. There is currently an incompatibility between the architecture of the latest image (ARM64) with Dataproc's own architecture (AMD64).

The latest Docker images uploaded to the Registry were built using `docker build`, meaning that the image is built for the architecture of the local system. With `docker buildx` we can do multi architecture builds to solve the issue. I've taken [the action in Gentropy](https://github.com/opentargets/gentropy/blob/4104ce3efc54e0db2f622940fc43ff46c3e26bdf/.github/workflows/artifact.yml#L36) as a template.

We have to merge it to test it.