### PR TITLE
fix: specify numpy and scipy versions to enable running in dataproc

### DIFF
--- a/metric-calculation/requirements.txt
+++ b/metric-calculation/requirements.txt
@@ -9,3 +9,5 @@ pyspark>=3.2.0
 furl==2.1.3
 psutil>=5.8.0
 urllib3==1.26.6
+numpy==1.26.4
+scipy==1.14.1


### PR DESCRIPTION
This PR adds specific numpy and scipy versions to the metrics app requirements.txt file. This enables running the metrics script in dataproc. (These may have to be updated if the Python version/other dependencies in dataproc are changed)