### PR TITLE
feat (metrics): add subnet parameter for dataproc job

### DIFF
--- a/docs/metric-calculation.md
+++ b/docs/metric-calculation.md
@@ -18,11 +18,13 @@ export IMAGE=europe-west1-docker.pkg.dev/open-targets-eu-dev/ot-release-metrics/
 export PROJECT=open-targets-eu-dev
 export REGION=europe-west1
 export BUCKET=gs://ot-release-metrics
+export SUBNET=ot-dataproc-serverless
 gcloud dataproc batches submit pyspark \
     --container-image ${IMAGE} \
     --region ${REGION} \
     --project ${PROJECT} \
     --deps-bucket ${BUCKET} \
+    --subnet ${SUBNET} \
     --files config/config.yaml \
     --properties "spark.executor.cores=16" \
     metric-calculation/src/metric_calculation/metrics.py \


### PR DESCRIPTION
The dataproc job for the metric calculation was failing as it was unable to login to huggingface. This is because the job was unable to access the internet in general.

To enable internet access, the custom VPC network `ot-dataproc-serverless` was created along with a cloud router and NAT and relevant firewall rules. (These are all prefixed with `ot-dataproc-serverless`).

This PR adds the subnet parameter to the dataproc job submission script.