### PR TITLE
fix(metrics): update path to configuration file

### DIFF
--- a/docs/metric-visualisation.md
+++ b/docs/metric-visualisation.md
@@ -3,7 +3,7 @@ The app is deployed here: **https://open-targets-metrics.streamlit.app/**
 
 
 ## Running the web app to visualise and compare the metrics
-To start the app locally, run `streamlit run app.py`.
+To start the app locally, run the Docker image stored in the GCP container registry with `docker run -p 8501:8501 europe-west1-docker.pkg.dev/open-targets-eu-dev/ot-release-metrics/app:latest`. A new instances will be deployed using port 8501.
 
 If you encounter a `TomlDecodeError`, this can be resolved by removing the `~/.streamlit` folder.
 

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -23,7 +23,7 @@ def main(cfg: DictConfig):
     # App UI
     st.set_page_config(
         page_title="Open Targets Data Metrics",
-        page_icon=Image.open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "src/assets/img/favicon.png")),
+        page_icon=Image.open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "streamlit-app/src/assets/img/favicon.png")),
         layout="wide",
         initial_sidebar_state="expanded",
     )
@@ -325,7 +325,7 @@ def main(cfg: DictConfig):
             st.plotly_chart(plot_enrichment(data), use_container_width=True)
 
     st.markdown("###")
-    st.image(Image.open("src/assets/img/logo.png"), width=150)
+    st.image(Image.open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "streamlit-app/src/assets/img/logo.png")), width=150)
 
 
 if __name__ == "__main__":

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -19,6 +19,9 @@ from src.utils import (
 
 @hydra.main(version_base=None, config_path="config", config_name="config")
 def main(cfg: DictConfig):
+    # print path of the current working directory
+    import os
+    print(f"Working directory: {os.getcwd()}")
     # App UI
     st.set_page_config(
         page_title="Open Targets Data Metrics",

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -17,7 +17,7 @@ from src.utils import (
 )
 
 
-@hydra.main(version_base=None, config_path="config", config_name="config")
+@hydra.main(version_base=None, config_path="../config", config_name="config")
 def main(cfg: DictConfig):
     # print path of the current working directory
     import os

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -23,7 +23,7 @@ def main(cfg: DictConfig):
     # App UI
     st.set_page_config(
         page_title="Open Targets Data Metrics",
-        page_icon=Image.open("src/assets/img/favicon.png"),
+        page_icon=Image.open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "src/assets/img/favicon.png")),
         layout="wide",
         initial_sidebar_state="expanded",
     )

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -1,6 +1,7 @@
 from functools import reduce
 
 import hydra
+import os
 from omegaconf import DictConfig
 import pandas as pd
 from PIL import Image
@@ -17,11 +18,8 @@ from src.utils import (
 )
 
 
-@hydra.main(version_base=None, config_path="../config", config_name="config")
+@hydra.main(version_base=None, config_path=os.path.join(os.path.dirname(os.path.dirname(__file__)), "config"), config_name="config")
 def main(cfg: DictConfig):
-    # print path of the current working directory
-    import os
-    print(f"Working directory: {os.getcwd()}")
     # App UI
     st.set_page_config(
         page_title="Open Targets Data Metrics",


### PR DESCRIPTION
This PR fixes an issue with the Streamlit app deployed by Streamlit Cloud, where the configuration file could not be loaded. This was because the app and the configuration wasn't in the same directory.

We have updated the app script to use absolute paths, so that it is always relative to the working directory.
The app is working now, it can be browsed here https://ot-release-metrics-f5wnkpbdfhjjizipykpmce.streamlit.app/

PR co-created with @vivienho 