### PR TITLE
feat: remove `pis` logic and adjust pre etl metrics

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,24 +4,20 @@ metric_calculation:
   ot_release: ???
 
   data_repositories:
-    release_output_root: gs://open-targets-pre-data-releases/${metric_calculation.ot_release}/output
-    metadata_output_root: gs://open-targets-pre-data-releases/${metric_calculation.ot_release}/metadata
+    release_bucket: gs://open-targets-pre-data-releases
     metrics_root: gs://otar000-evidence_input/release-metrics
 
   datasets:
-    # Post ETL data.
-    evidence: ${metric_calculation.data_repositories.release_output_root}/evidence
-    evidence_failed: gs://open-targets-pre-data-releases/${metric_calculation.ot_release}/excluded/evidence
-    associations_overall_indirect: ${metric_calculation.data_repositories.release_output_root}/association_by_overall_indirect
-    associations_overall_direct: ${metric_calculation.data_repositories.release_output_root}/association_overall_direct
-    associations_source_indirect: ${metric_calculation.data_repositories.release_output_root}/association_by_datasource_indirect
-    associations_source_direct: ${metric_calculation.data_repositories.release_output_root}/association_by_datasource_direct
-    diseases: ${metric_calculation.data_repositories.release_output_root}/disease
-    targets: ${metric_calculation.data_repositories.release_output_root}/target
-    drugs: ${metric_calculation.data_repositories.release_output_root}/drug_molecule
-
-  metadata:
-    evidence: ${metric_calculation.data_repositories.metadata_output_root}/evidence
+    evidence_pre_etl: input/evidence
+    evidence_post_etl: output/evidence
+    evidence_failed: excluded/evidence
+    associations_overall_indirect: output/association_by_overall_indirect
+    associations_overall_direct: output/association_overall_direct
+    associations_source_indirect: output/association_by_datasource_indirect
+    associations_source_direct: output/association_by_datasource_direct
+    diseases: output/disease
+    targets: output/target
+    drugs: output/drug_molecule
 
   gold_standard:
     associations: ${metric_calculation.data_repositories.metrics_root}/gold-standard/informa_abbvie.tsv
@@ -29,7 +25,7 @@ metric_calculation:
 
   outputs:
     hf_repo_id: opentargets/ot-release-metrics
-    release_output_path: gs://open-targets-pre-data-releases/${metric_calculation.ot_release}/metrics.csv
+    release_output_path: ${metric_calculation.data_repositories.release_bucket}/${metric_calculation.ot_release}/metrics.csv
 
 metric_visualization:
   parameters:

--- a/metric-calculation/Dockerfile
+++ b/metric-calculation/Dockerfile
@@ -8,9 +8,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install utilities required by Spark scripts.
 RUN apt -qq update && apt -qq install -y procps tini libjemalloc2
 
-# Enable jemalloc2 as default memory allocator.
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-
 # Create the 'spark' group/user.
 RUN groupadd -g 1099 spark
 RUN useradd -u 1099 -g 1099 -d /home/spark -m spark
@@ -20,22 +17,19 @@ ENV PIP_PACKAGES=/home/spark/packages
 RUN mkdir -p "${PIP_PACKAGES}"
 
 
-
 # Part 2: ot-release-metrics specific setup.
 
 # Install main requirements.
 COPY metric-calculation/requirements.txt /home/spark/requirements.txt
 RUN python3 -m pip install -q --target "${PIP_PACKAGES}" -r /home/spark/requirements.txt
 
-# Install PIS and its requirements.
-ENV PIS_PATH=/home/spark/platform-input-support
-RUN python3 -m pip install -q --target "${PIP_PACKAGES}" configargparse strenum jsonpickle google-cloud-storage addict yapsy
-RUN git clone -b master https://github.com/opentargets/platform-input-support $PIS_PATH
-
 # Copy the main package.
 COPY metric-calculation/src ${PIP_PACKAGES}/src
 
+# Enable jemalloc2 as default memory allocator.
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 # Define Dataproc Serverless parameters.
-ENV PYTHONPATH="${PIP_PACKAGES}:${PIS_PATH}"
+ENV PYTHONPATH="${PIP_PACKAGES}:${PYTHONPATH}"
 RUN chmod -R 777 /home/spark
 USER spark

--- a/metric-calculation/src/metric_calculation/metrics.py
+++ b/metric-calculation/src/metric_calculation/metrics.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections import namedtuple
+from datetime import datetime
 from functools import reduce
 import logging
 import logging.config
@@ -20,10 +21,8 @@ from src.metric_calculation.utils import (
     access_gcp_secret,
     initialize_spark_session,
     read_path_if_provided,
-    fetch_pre_etl_evidence,
-    detect_release_timestamp,
     write_metrics_to_csv,
-    write_metrics_to_hf_hub
+    write_metrics_to_hf_hub,
 )
 
 if TYPE_CHECKING:
@@ -309,22 +308,30 @@ def get_columns_to_report(dataset_columns):
 
 
 def calculate_additional_post_etl_metrics(metrics_cfg):
-    evidence_failed = read_path_if_provided(metrics_cfg.datasets.evidence_failed)
+    evidence_failed = read_path_if_provided(
+        f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.evidence_failed}"
+    )
     associations_direct = read_path_if_provided(
-        metrics_cfg.datasets.associations_source_direct
+        f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.associations_source_direct}"
     )
     associations_indirect = read_path_if_provided(
-        metrics_cfg.datasets.associations_source_indirect
+        f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.associations_source_indirect}"
     )
     associations_overall_direct = read_path_if_provided(
-        metrics_cfg.datasets.associations_overall_direct
+        f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.associations_overall_direct}"
     )
     associations_overall_indirect = read_path_if_provided(
-        metrics_cfg.datasets.associations_overall_indirect
+        f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.associations_overall_indirect}"
     )
-    diseases = read_path_if_provided(metrics_cfg.datasets.diseases)
-    targets = read_path_if_provided(metrics_cfg.datasets.targets)
-    drugs = read_path_if_provided(metrics_cfg.datasets.drugs)
+    diseases = read_path_if_provided(
+        f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.diseases}"
+    )
+    targets = read_path_if_provided(
+        f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.targets}"
+    )
+    drugs = read_path_if_provided(
+        f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.drugs}"
+    )
     gold_standard_associations = read_path_if_provided(
         metrics_cfg.gold_standard.associations
     )
@@ -541,7 +548,8 @@ def calculate_additional_post_etl_metrics(metrics_cfg):
 
 @hydra.main(config_path=os.getcwd(), config_name="config")
 def main(cfg: DictConfig) -> None:
-    global spark
+    global spark, ot_release_bucket
+    cfg = cfg.metric_calculation
     spark = initialize_spark_session()
 
     logging_config = {
@@ -551,30 +559,36 @@ def main(cfg: DictConfig) -> None:
     }
     logging.basicConfig(**logging_config)
 
-    # Determine type of run and load evidence accordingly.
-    cfg = cfg.metric_calculation
+    # Determine type of run
     ot_release = str(cfg.ot_release)
+    ot_release_bucket = ot_release.replace("_pre", "")
+    release_timestamp = datetime.today().strftime("%Y-%m-%d")
     if ot_release.endswith("_pre"):
-        # Pre-ETL mode.
+        # Pre-ETL mode. Example: "23.12_pre".
         is_pre_etl_run = True
-        run_id = ot_release  # Example: "23.12_pre".
-        logging.info(f"Fetching evidence for pre-ETL run {run_id}")
-        evidence = fetch_pre_etl_evidence()
+        run_id = f"{ot_release}_{release_timestamp}"
     else:
         # Post-ETL mode.
         is_pre_etl_run = False
-        release_timestamp = detect_release_timestamp(cfg.metadata.evidence)
         if ot_release.startswith("partners/"):
             # Remove the "partners" prefix which was important for locating the files.
-            ot_release = ot_release.split('/')[1] + "_ppp"
+            ot_release = ot_release.split("/")[1] + "_ppp"
         # Calculate the final run ID:
         # - Example for regular: "23.12_2023-10-26".
         # - Example for PPP: "23.12_ppp_2023-11-27".
         run_id = f"{ot_release}_{release_timestamp}"
-        logging.info(f"Reading evidence for post-ETL run {run_id}")
-        evidence = read_path_if_provided(cfg.datasets.evidence)
 
     # Process evidence metrics.
+    evidence = (
+        read_path_if_provided(
+            f"{cfg.data_repositories.release_bucket}/{ot_release_bucket}/{cfg.datasets.evidence_pre_etl}",
+            dir_format="json",
+        )
+        if is_pre_etl_run
+        else read_path_if_provided(
+            f"{cfg.data_repositories.release_bucket}/{ot_release_bucket}/{cfg.datasets.evidence_post_etl}"
+        )
+    )
     datasets = []
     if evidence:
         logging.info("Running evidence metrics.")
@@ -613,9 +627,11 @@ def main(cfg: DictConfig) -> None:
         metrics,
         file_output_name=f"{run_id}.csv",
         repo_id=cfg.outputs.hf_repo_id,
-        hf_token=access_gcp_secret("hfhub-key", "open-targets-eu-dev")
+        hf_token=access_gcp_secret("hfhub-key", "open-targets-eu-dev"),
     )
-    logging.info(f"Metrics {run_id}.csv have been uploaded to HG Hub app: {cfg.outputs.hf_repo_id}")
+    logging.info(
+        f"Metrics {run_id}.csv have been uploaded to HG Hub app: {cfg.outputs.hf_repo_id}"
+    )
 
     if not ot_release.endswith("_pre"):
         write_metrics_to_csv(metrics, cfg.outputs.release_output_path)

--- a/metric-calculation/src/metric_calculation/utils.py
+++ b/metric-calculation/src/metric_calculation/utils.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-import yaml
 
-from addict import Dict
 from datasets import Dataset
 import gcsfs
 from huggingface_hub import login
 from pyspark.sql import SparkSession
-import pyspark.sql.functions as f
-
-from modules.common.Downloads import Downloads
-from modules.common.GoogleBucketResource import GoogleBucketResource
 
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame
+
 
 def access_gcp_secret(secret_id: str, project_id: str) -> str:
     """Access GCP secret manager to get the secret value.
@@ -33,12 +28,13 @@ def access_gcp_secret(secret_id: str, project_id: str) -> str:
     response = client.access_secret_version(name=name)
     return response.payload.data.decode("UTF-8")
 
+
 def initialize_spark_session():
     """Creates and returns a SparkSession object."""
     return SparkSession.builder.getOrCreate()
 
 
-def read_path_if_provided(path: str, dir_format="parquet"):
+def read_path_if_provided(path: str | None, dir_format="parquet"):
     """
     Automatically detect the format of the input data and read it into the Spark dataframe. The supported formats
     are: a single TSV file; a single JSON file; a directory with JSON files; a directory with Parquet files.
@@ -48,9 +44,9 @@ def read_path_if_provided(path: str, dir_format="parquet"):
         return None
 
     # The provided path must exist and must be either a file or a directory.
-    assert gcsfs.GCSFileSystem().exists(
-        path
-    ), f"The provided path {path} does not exist."
+    assert gcsfs.GCSFileSystem().exists(path), (
+        f"The provided path {path} does not exist."
+    )
 
     # Case 1: We are provided with a single file.
     if gcsfs.GCSFileSystem().isfile(path):
@@ -83,51 +79,12 @@ def write_metrics_to_csv(metrics: DataFrame, output_path: str):
     metrics.toPandas().to_csv(output_path, index=False, header=True)
 
 
-def detect_release_timestamp(evidence_metadata_path):
-    """Automatically detects ETL run timestamp based on the latest update time."""
-    evidence_metadata = read_path_if_provided(evidence_metadata_path, dir_format="json")
-    parquet_rows = evidence_metadata.filter(
-        f.col("resource").getField("format") == "parquet"
-    ).collect()
-    assert (
-        len(parquet_rows) == 1
-    ), "There should be exactly one row with Parquet metadata"
-    update_timestamp = parquet_rows[
-        0
-    ].timeStamp  # Example format: "2023-10-31T18:11:57.508Z".
-    return update_timestamp[:10]  # Example format: "2023-10-31".
-
-
-def fetch_pre_etl_evidence():
-    """Returns latest evidence for each input source, fetched using PIS code."""
-    pis_config = Dict(
-        yaml.load(
-            open("/home/spark/platform-input-support/config.yaml").read(),
-            yaml.SafeLoader,
-        )
-    )
-
-    # Instantiate a helper class to identify the latest file in each bucket.
-    pis_downloads = Downloads(None)
-
-    # Identify latest files for each evidence source.
-    all_files = []
-    for resource in pis_config.evidence.gs_downloads_latest:
-        bucket_name, path = GoogleBucketResource.get_bucket_and_path(resource.bucket)
-        google_resource = GoogleBucketResource(bucket_name, path)
-        latest_resource = pis_downloads.get_latest(google_resource, resource)
-        latest_filename = latest_resource["latest_filename"]
-        all_files.append(f"gs://{bucket_name}/{latest_filename}")
-
-    # Read all files into Spark.
-    return SparkSession.getActiveSession().read.json(all_files)
-
 def write_metrics_to_hf_hub(
     metrics_df: DataFrame,
     file_output_name: str,
     repo_id: str = "opentargets/ot-release-metrics",
     data_dir: str = "metrics",
-    hf_token : str | None = None,
+    hf_token: str | None = None,
 ) -> None:
     """Upload dataset of metrics to HuggingFace Hub."""
     assert file_output_name.endswith(".csv"), "Only CSV files are supported."


### PR DESCRIPTION
These changes mean that the metrics repo no longer takes care of pulling all evidence files pre release using PIS.
This data is now expected to be in the `input` directory of the release bucket, making it easier to be plugged inside the orchestration layer (more context on the ticket ↓)
Closes https://github.com/opentargets/issues/issues/3865


## Description
This PR includes:

- Removal of old PIS dependency from the metrics Dockerfile (image is uploaded to the Registry)
- Removal of any logic that called PIS in the metrics calculation: `utils.fetch_pre_etl_evidence` and its reference in `metrics.py`
- We no longer use the metadata file as a dependency to define the run ID
- Refactor of `configuration.yaml` and the usage of the inputs by `metrics.py` to adapt to the proposed diagram

```mermaid
flowchart TD
    subgraph Pre-ETL
    A[PIS]:::redBox --> AB(Data collection)
    AB --> AC(Metrics)
    end

    subgraph Post-ETL
    BA[Release input bucket]
    BA --> BC[Metrics]
    end

    Pre-ETL --- ETL[ETL]:::redBox
    ETL -.-> Post-ETL
    
    %% Force layout
    Post-ETL ---| |ETL
    linkStyle 3 stroke-width:0px;
    linkStyle 5 stroke-width:0px;

    classDef redBox fill:#ffcccc;
```

## Acceptance tests
Tested that the new approach works:
- [Pre ETL metrics Job](https://console.cloud.google.com/dataproc/batches/europe-west1/c13fe5ce161f43f3adde4aae0e45329c/summary?authuser=1&invt=Abvalw&project=open-targets-eu-dev)
- [Post ETL metrics Job](https://console.cloud.google.com/dataproc/batches/europe-west1/746e8c5975834fd888aa38c2106d82bd/summary?authuser=1&invt=Abvalw&project=open-targets-eu-dev)
- [PPP metrics Job](https://console.cloud.google.com/dataproc/batches/europe-west1/25c284341da542bdaf497f6ef3b5e75f/summary?authuser=1&invt=Abvalw&project=open-targets-eu-dev)