### PR TITLE
fix: harmonise paths to different deployment environments

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,7 +27,3 @@ metric_calculation:
     hf_repo_id: opentargets/ot-release-metrics
     release_output_path: ${metric_calculation.data_repositories.release_bucket}/${metric_calculation.ot_release}/metrics.csv
 
-metric_visualization:
-  parameters:
-    yellow_highlight_bound: 0.2
-    red_highlight_bound: 0.5

--- a/streamlit-app/Dockerfile
+++ b/streamlit-app/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY streamlit-app/requirements.txt .
-COPY config ./config
 COPY streamlit-app/src ./src
 COPY streamlit-app/app.py .
 

--- a/streamlit-app/Dockerfile
+++ b/streamlit-app/Dockerfile
@@ -9,12 +9,12 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-COPY streamlit-app/requirements.txt /streamlit-app/requirements.txt
-COPY config /streamlit-app/config
-COPY streamlit-app /streamlit-app
+COPY streamlit-app/requirements.txt .
+COPY config ./config
+COPY streamlit-app/src ./src
+COPY streamlit-app/app.py .
 
 RUN pip3 install -r requirements.txt
-
 
 EXPOSE 8501
 

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -10,6 +10,7 @@ from src.utils import (
     extract_primary_run_id_list,
     show_table,
     get_config_path,
+    get_asset_path,
     load_data_from_hf,
     plot_enrichment,
     compare_entity,
@@ -23,7 +24,7 @@ def main(cfg: DictConfig):
     # App UI
     st.set_page_config(
         page_title="Open Targets Data Metrics",
-        page_icon=Image.open("src/assets/img/favicon.png"),
+        page_icon=Image.open(get_asset_path("src/assets/img/favicon.png")),
         layout="wide",
         initial_sidebar_state="expanded",
     )
@@ -325,7 +326,7 @@ def main(cfg: DictConfig):
             st.plotly_chart(plot_enrichment(data), use_container_width=True)
 
     st.markdown("###")
-    st.image(Image.open("src/assets/img/logo.png"), width=150)
+    st.image(Image.open(get_asset_path("src/assets/img/logo.png")), width=150)
 
 
 if __name__ == "__main__":

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -23,7 +23,7 @@ def main(cfg: DictConfig):
     # App UI
     st.set_page_config(
         page_title="Open Targets Data Metrics",
-        page_icon=Image.open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "streamlit-app/src/assets/img/favicon.png")),
+        page_icon=Image.open("src/assets/img/favicon.png"),
         layout="wide",
         initial_sidebar_state="expanded",
     )
@@ -325,7 +325,7 @@ def main(cfg: DictConfig):
             st.plotly_chart(plot_enrichment(data), use_container_width=True)
 
     st.markdown("###")
-    st.image(Image.open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "streamlit-app/src/assets/img/logo.png")), width=150)
+    st.image(Image.open("src/assets/img/logo.png"), width=150)
 
 
 if __name__ == "__main__":

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -1,7 +1,8 @@
-from functools import reduce
+from functools import lru_cache, reduce
+from pathlib import Path
 
 import hydra
-from omegaconf import DictConfig
+from hydra.core.global_hydra import GlobalHydra
 import pandas as pd
 from PIL import Image
 import streamlit as st
@@ -18,9 +19,16 @@ from src.utils import (
     select_and_mask_data_to_explore,
 )
 
+@lru_cache(maxsize=None)
+def get_hydra_config():
+    """Clear hydra instance and initialize with relative config path."""
+    GlobalHydra.instance().clear()
+    # Hydra needs a relative path to the config directory
+    config_dir = Path(get_config_path()).relative_to(Path.cwd())
+    hydra.initialize(version_base=None, config_path=str(config_dir))
+    return hydra.compose(config_name="config")
 
-@hydra.main(version_base=None, config_path=get_config_path(), config_name="config")
-def main(cfg: DictConfig):
+def main():
     # App UI
     st.set_page_config(
         page_title="Open Targets Data Metrics",
@@ -51,6 +59,7 @@ def main(cfg: DictConfig):
             "allows you to compare the main metrics between two releases."
         ),
     )
+    cfg = get_hydra_config()
     data = load_data_from_hf()
     all_runs = list(data.runId.unique())
     all_releases = extract_primary_run_id_list(all_runs)

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -1,8 +1,5 @@
-from functools import lru_cache, reduce
-from pathlib import Path
+from functools import reduce
 
-import hydra
-from hydra.core.global_hydra import GlobalHydra
 import pandas as pd
 from PIL import Image
 import streamlit as st
@@ -10,7 +7,6 @@ import streamlit as st
 from src.utils import (
     extract_primary_run_id_list,
     show_table,
-    get_config_path,
     get_asset_path,
     load_data_from_hf,
     plot_enrichment,
@@ -19,14 +15,9 @@ from src.utils import (
     select_and_mask_data_to_explore,
 )
 
-@lru_cache(maxsize=None)
-def get_hydra_config():
-    """Clear hydra instance and initialize with relative config path."""
-    GlobalHydra.instance().clear()
-    # Hydra needs a relative path to the config directory
-    config_dir = Path(get_config_path()).relative_to(Path.cwd())
-    hydra.initialize(version_base=None, config_path=str(config_dir))
-    return hydra.compose(config_name="config")
+YELLOW_HIGHLIGHT_BOUND = 0.2
+RED_HIGHLIGHT_BOUND = 0.5
+
 
 def main():
     # App UI
@@ -59,13 +50,14 @@ def main():
             "allows you to compare the main metrics between two releases."
         ),
     )
-    cfg = get_hydra_config()
     data = load_data_from_hf()
     all_runs = list(data.runId.unique())
     all_releases = extract_primary_run_id_list(all_runs)
 
     if page == "Explore metrics":
-        data, selected_run = select_and_mask_data_to_explore(all_releases, all_runs, data)
+        data, selected_run = select_and_mask_data_to_explore(
+            all_releases, all_runs, data
+        )
         if selected_run:
             st.markdown("## Key metrics")
             col1, col2, col3, col4, col5 = st.columns(5)
@@ -155,7 +147,9 @@ def main():
             )
 
     if page == "Compare metrics":
-        data, selected_runs = select_and_mask_data_to_compare(all_releases, all_runs, data)
+        data, selected_runs = select_and_mask_data_to_compare(
+            all_releases, all_runs, data
+        )
 
         if selected_runs:
             latest_run, previous_run = selected_runs
@@ -325,12 +319,14 @@ def main():
                     name,
                     latest_run,
                     df,
-                    cfg.metric_visualization.parameters.yellow_highlight_bound,
-                    cfg.metric_visualization.parameters.red_highlight_bound,
+                    YELLOW_HIGHLIGHT_BOUND,
+                    RED_HIGHLIGHT_BOUND,
                 )
 
     if page == "Visualise metrics":
-        data, selected_runs = select_and_mask_data_to_compare(all_releases, all_runs, data)
+        data, selected_runs = select_and_mask_data_to_compare(
+            all_releases, all_runs, data
+        )
         if selected_runs:
             st.plotly_chart(plot_enrichment(data), use_container_width=True)
 

--- a/streamlit-app/app.py
+++ b/streamlit-app/app.py
@@ -1,7 +1,6 @@
 from functools import reduce
 
 import hydra
-import os
 from omegaconf import DictConfig
 import pandas as pd
 from PIL import Image
@@ -10,6 +9,7 @@ import streamlit as st
 from src.utils import (
     extract_primary_run_id_list,
     show_table,
+    get_config_path,
     load_data_from_hf,
     plot_enrichment,
     compare_entity,
@@ -18,7 +18,7 @@ from src.utils import (
 )
 
 
-@hydra.main(version_base=None, config_path=os.path.join(os.path.dirname(os.path.dirname(__file__)), "config"), config_name="config")
+@hydra.main(version_base=None, config_path=get_config_path(), config_name="config")
 def main(cfg: DictConfig):
     # App UI
     st.set_page_config(

--- a/streamlit-app/src/utils.py
+++ b/streamlit-app/src/utils.py
@@ -10,13 +10,11 @@ import plotly.express as px
 import streamlit as st
 
 
-def resolve_path(path_type: str, relative_path: str = "") -> str:
-    """
-    Resolve paths for different resource types across environments.
+def get_asset_path(relative_path: str = "") -> str:
+    """Resolve asset paths across different environments.
 
     Args:
-        path_type: Either "config" or "asset"
-        relative_path: The path relative to the resource root (only for assets)
+        relative_path: The path relative to the asset root
 
     Returns:
         Absolute path as string
@@ -28,35 +26,19 @@ def resolve_path(path_type: str, relative_path: str = "") -> str:
         Path(__file__).parent.parent.parent,  # Local dev (from utils.py)
         Path("/app"),  # Docker
     ]
+    path_structures = [
+        Path("streamlit-app") / relative_path,
+        Path(relative_path),
+    ]
 
-    # Define different path structures for each type
-    path_structures = {
-        "config": [
-            Path("config"),  # Direct config directory
-            Path("streamlit-app/config"),  # Nested config directory
-        ],
-        "asset": [
-            Path("streamlit-app") / relative_path,  # Production path
-            Path(relative_path),  # Simpler local path
-        ],
-    }
-
-    # Locate path to asset or config
+    # Locate path to asset
     for root in possible_roots:
-        for path_structure in path_structures[path_type]:
+        for path_structure in path_structures:
             full_path = root / path_structure
             if full_path.exists():
                 return str(full_path)
 
-    raise FileNotFoundError(f"Could not find {path_type} at {relative_path}.")
-
-
-def get_config_path() -> str:
-    return resolve_path("config")
-
-
-def get_asset_path(relative_path: str) -> str:
-    return resolve_path("asset", relative_path)
+    raise FileNotFoundError(f"Could not find asset at {relative_path}.")
 
 
 def show_table(

--- a/streamlit-app/src/utils.py
+++ b/streamlit-app/src/utils.py
@@ -8,8 +8,6 @@ import pandas as pd
 import plotly.express as px
 import streamlit as st
 
-logger = logging.getLogger(__name__)
-
 def get_config_path() -> str:
     """Get the path to the config directory based on the deployment environment."""
     paths_to_check = [
@@ -18,15 +16,20 @@ def get_config_path() -> str:
         os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "streamlit-app", "config"),  # Alternative local path
     ]
     
+    st.write("Checking config paths:")
     for path in paths_to_check:
-        logger.info(f"Checking config path: {path}")
-        logger.info(f"Path exists: {os.path.exists(path)}")
+        st.write(f"Checking path: {path}")
+        st.write(f"Path exists: {os.path.exists(path)}")
         
         if os.path.exists(path):
-            logger.info(f"Found config directory at: {path}")
+            st.write(f"Found config directory at: {path}")
             return path
     
-    logger.error("Could not find config directory in any of the checked locations")
+    st.error("Could not find config directory in any of the checked locations")
+    st.error("Checked paths:")
+    for path in paths_to_check:
+        st.error(path)
+    
     raise FileNotFoundError(
         "Could not find config directory. Checked paths:\n" + 
         "\n".join(paths_to_check)

--- a/streamlit-app/src/utils.py
+++ b/streamlit-app/src/utils.py
@@ -9,29 +9,55 @@ import pandas as pd
 import plotly.express as px
 import streamlit as st
 
+from pathlib import Path
+from typing import Literal
+
+
+def resolve_path(path_type: str, relative_path: str = "") -> str:
+    """
+    Resolve paths for different resource types across environments.
+
+    Args:
+        path_type: Either "config" or "asset"
+        relative_path: The path relative to the resource root (only for assets)
+
+    Returns:
+        Absolute path as string
+    """
+    # Define possible root locations in search order
+    possible_roots = [
+        Path("/mount/src/ot-release-metrics"),  # Streamlit Cloud absolute
+        Path.cwd(),  # Streamlit Cloud relative
+        Path(__file__).parent.parent.parent,  # Local dev (from utils.py)
+        Path("/app"),  # Docker
+    ]
+
+    # Define different path structures for each type
+    path_structures = {
+        "config": [
+            Path("config"),  # Direct config directory
+            Path("streamlit-app/config"),  # Nested config directory
+        ],
+        "asset": [
+            Path("streamlit-app") / relative_path,  # Production path
+            Path(relative_path),  # Simpler local path
+        ],
+    }
+
+    # Locate path to asset or config
+    for root in possible_roots:
+        for path_structure in path_structures[path_type]:
+            full_path = root / path_structure
+            if full_path.exists():
+                return str(full_path)
+
+    raise FileNotFoundError(f"Could not find {path_type} at {relative_path}.")
+
 def get_config_path() -> str:
-    """Get the path to the config directory based on the deployment environment."""
-    # 1. Streamlit Cloud path assuming working dir is project root
-    streamlit_cloud_path = Path("/mount/src/ot-release-metrics/config")
-    if streamlit_cloud_path.exists():
-        return str(streamlit_cloud_path)
-    
-    # 2. Relative path from project root (for Streamlit Cloud)
-    project_root_path = Path("config")
-    if project_root_path.exists():
-        return str(project_root_path)
-    
-    # 3. Local development path (relative to utils.py location)
-    local_path = Path(__file__).parent.parent.parent / "config"
-    if local_path.exists():
-        return str(local_path)
-    
-    raise FileNotFoundError(
-        "Could not find config directory in any of the expected locations:\n"
-        f"1. {streamlit_cloud_path}\n"
-        f"2. {project_root_path}\n"
-        f"3. {local_path}\n"
-    )
+    return resolve_path("config")
+
+def get_asset_path(relative_path: str) -> str:
+    return resolve_path("asset", relative_path)
 
 def show_table(
     name: str, latest_run: str, df: pd.DataFrame, yellow_bound: float, red_bound: float
@@ -93,13 +119,15 @@ def highlight_cell(
 
     return background
 
+
 @st.cache_data(ttl="1h")
-def load_data_from_hf(hf_repo_id: str = "opentargets/ot-release-metrics",) -> pd.DataFrame:
+def load_data_from_hf(
+    hf_repo_id: str = "opentargets/ot-release-metrics",
+) -> pd.DataFrame:
     """Pulls Platform metrics from HuggingFace Hub."""
     fs = HfFileSystem()
     all_hf_paths = [
-        f"hf://{path}"
-        for path in fs.glob(f"datasets/{hf_repo_id}/metrics/*.csv")
+        f"hf://{path}" for path in fs.glob(f"datasets/{hf_repo_id}/metrics/*.csv")
     ]
     logging.info(f"Number of csv files found in the data folder: {len(all_hf_paths)}")
     data = pd.concat(
@@ -107,11 +135,16 @@ def load_data_from_hf(hf_repo_id: str = "opentargets/ot-release-metrics",) -> pd
         ignore_index=True,
     ).fillna({"value": 0})
     logging.info(f"Number of datasets: {len(data.runId.unique())}")
-    assert len(data.runId.unique()) == len(all_hf_paths), "Number of datasets does not match number of metrics runs."
+    assert len(data.runId.unique()) == len(all_hf_paths), (
+        "Number of datasets does not match number of metrics runs."
+    )
     return data
 
+
 @st.cache_data(ttl="1h")
-def load_data(data_folder: str, ) -> pd.DataFrame:
+def load_data(
+    data_folder: str,
+) -> pd.DataFrame:
     """This function reads all csv files from a provided location and returns as a concatenated pandas dataframe"""
 
     # Get list of csv files in a Google bucket:
@@ -226,7 +259,8 @@ def show_total_between_runs_for_entity(
         # Prettify column names
         .assign(runId=lambda df: f"Nr of {entity_name} in " + df["runId"])
         # Transpose dataframe to have the runIds as columns
-        .set_index("runId").T
+        .set_index("runId")
+        .T
     )
 
 
@@ -294,24 +328,39 @@ def compare_entity(
 
     return df
 
+
 def extract_primary_run_id_list(all_run_ids: list[str]) -> list[str]:
     """Generates a runId selector based on the runIds. This is used to identify to which major runId the metrics belong to.
-    
+
     Examples:
     >>> extract_primary_run_id_list(["2023.09", "2023.09-pre", "2023.11-ppp"])
     ["2023.11", "2023.09"]
     """
     primary_run_id_pattern = r"^\d+.\d+"
-    return ["All"] + sorted(list({re.match(primary_run_id_pattern, x).group() for x in all_run_ids}), reverse=True) # type: ignore
+    return ["All"] + sorted(
+        list({re.match(primary_run_id_pattern, x).group() for x in all_run_ids}),
+        reverse=True,
+    )  # type: ignore
 
-def extract_secondary_run_id_list(all_run_ids: list[str], primary_run_ids: list[str]) -> list[str]:
+
+def extract_secondary_run_id_list(
+    all_run_ids: list[str], primary_run_ids: list[str]
+) -> list[str]:
     """Generates a runId selector based on the runIds. This is used to identify to which major runId the metrics belong to.
-    
+
     Examples:
     >>> extract_secondary_run_id_list(["2023.09", "2023.09-pre", "2023.11-ppp"], ["2023.11"])
     ["2023.11-ppp"]
     """
-    return sorted([run_id for run_id in all_run_ids if any(primary_id in run_id for primary_id in primary_run_ids)], reverse=True)
+    return sorted(
+        [
+            run_id
+            for run_id in all_run_ids
+            if any(primary_id in run_id for primary_id in primary_run_ids)
+        ],
+        reverse=True,
+    )
+
 
 def select_and_mask_data_to_compare(all_releases, all_runs, data):
     st.sidebar.header("What do you want to compare?")
@@ -324,12 +373,15 @@ def select_and_mask_data_to_compare(all_releases, all_runs, data):
         select_runs = st.sidebar.multiselect(
             "Select two specific release runs:",
             extract_secondary_run_id_list(all_runs, select_releases),
-            help="First indicate the latest run and secondly the run with which you wish to make the comparison. Legend: IDs without a suffix are post-ETL, the latest run belongs to the data in production, 'pre' means pre-ETL and 'ppp' means partner preview platform."
+            help="First indicate the latest run and secondly the run with which you wish to make the comparison. Legend: IDs without a suffix are post-ETL, the latest run belongs to the data in production, 'pre' means pre-ETL and 'ppp' means partner preview platform.",
         )
-        masks_run = (data["runId"] == select_runs[0]) | (data["runId"] == select_runs[1])
+        masks_run = (data["runId"] == select_runs[0]) | (
+            data["runId"] == select_runs[1]
+        )
         filtered_data = data[masks_run]
         return filtered_data, select_runs
     return data, []
+
 
 def select_and_mask_data_to_explore(all_releases, all_runs, data):
     st.sidebar.header("What do you want to explore?")
@@ -337,8 +389,10 @@ def select_and_mask_data_to_explore(all_releases, all_runs, data):
 
     if select_release != "All":
         select_run = st.sidebar.selectbox(
-                "Select a specific release run:", extract_secondary_run_id_list(all_runs, select_release), help="Legend: IDs without a suffix are post-ETL, the latest run belongs to the data in production, 'pre' means pre-ETL and 'ppp' means partner preview platform."
-            )
+            "Select a specific release run:",
+            extract_secondary_run_id_list(all_runs, select_release),
+            help="Legend: IDs without a suffix are post-ETL, the latest run belongs to the data in production, 'pre' means pre-ETL and 'ppp' means partner preview platform.",
+        )
         mask_run = data["runId"] == select_run
         data = data[mask_run]
 

--- a/streamlit-app/src/utils.py
+++ b/streamlit-app/src/utils.py
@@ -8,6 +8,17 @@ import pandas as pd
 import plotly.express as px
 import streamlit as st
 
+def get_config_path() -> str:
+    """Get the path to the config directory based on the deployment environment."""
+    streamlit_cloud_path = "/mount/src/ot-release-metrics/streamlit-app/config"
+    local_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config")
+    
+    if os.path.exists(streamlit_cloud_path):
+        return streamlit_cloud_path
+    elif os.path.exists(local_path):
+        return local_path
+    else:
+        raise FileNotFoundError("Could not find config directory in either Streamlit Cloud or local path")
 
 def show_table(
     name: str, latest_run: str, df: pd.DataFrame, yellow_bound: float, red_bound: float

--- a/streamlit-app/src/utils.py
+++ b/streamlit-app/src/utils.py
@@ -8,17 +8,29 @@ import pandas as pd
 import plotly.express as px
 import streamlit as st
 
+logger = logging.getLogger(__name__)
+
 def get_config_path() -> str:
     """Get the path to the config directory based on the deployment environment."""
-    streamlit_cloud_path = "/mount/src/ot-release-metrics/streamlit-app/config"
-    local_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config")
+    paths_to_check = [
+        "/mount/src/ot-release-metrics/streamlit-app/config",  # Streamlit Cloud path
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "config"),  # Local path relative to utils.py
+        os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "streamlit-app", "config"),  # Alternative local path
+    ]
     
-    if os.path.exists(streamlit_cloud_path):
-        return streamlit_cloud_path
-    elif os.path.exists(local_path):
-        return local_path
-    else:
-        raise FileNotFoundError("Could not find config directory in either Streamlit Cloud or local path")
+    for path in paths_to_check:
+        logger.info(f"Checking config path: {path}")
+        logger.info(f"Path exists: {os.path.exists(path)}")
+        
+        if os.path.exists(path):
+            logger.info(f"Found config directory at: {path}")
+            return path
+    
+    logger.error("Could not find config directory in any of the checked locations")
+    raise FileNotFoundError(
+        "Could not find config directory. Checked paths:\n" + 
+        "\n".join(paths_to_check)
+    )
 
 def show_table(
     name: str, latest_run: str, df: pd.DataFrame, yellow_bound: float, red_bound: float

--- a/streamlit-app/src/utils.py
+++ b/streamlit-app/src/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 import re
 
 import gcsfs
@@ -10,29 +11,26 @@ import streamlit as st
 
 def get_config_path() -> str:
     """Get the path to the config directory based on the deployment environment."""
-    paths_to_check = [
-        "/mount/src/ot-release-metrics/streamlit-app/config",  # Streamlit Cloud path
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "config"),  # Local path relative to utils.py
-        os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "streamlit-app", "config"),  # Alternative local path
-    ]
+    # 1. Streamlit Cloud path assuming working dir is project root
+    streamlit_cloud_path = Path("/mount/src/ot-release-metrics/config")
+    if streamlit_cloud_path.exists():
+        return str(streamlit_cloud_path)
     
-    st.write("Checking config paths:")
-    for path in paths_to_check:
-        st.write(f"Checking path: {path}")
-        st.write(f"Path exists: {os.path.exists(path)}")
-        
-        if os.path.exists(path):
-            st.write(f"Found config directory at: {path}")
-            return path
+    # 2. Relative path from project root (for Streamlit Cloud)
+    project_root_path = Path("config")
+    if project_root_path.exists():
+        return str(project_root_path)
     
-    st.error("Could not find config directory in any of the checked locations")
-    st.error("Checked paths:")
-    for path in paths_to_check:
-        st.error(path)
+    # 3. Local development path (relative to utils.py location)
+    local_path = Path(__file__).parent.parent.parent / "config"
+    if local_path.exists():
+        return str(local_path)
     
     raise FileNotFoundError(
-        "Could not find config directory. Checked paths:\n" + 
-        "\n".join(paths_to_check)
+        "Could not find config directory in any of the expected locations:\n"
+        f"1. {streamlit_cloud_path}\n"
+        f"2. {project_root_path}\n"
+        f"3. {local_path}\n"
     )
 
 def show_table(

--- a/streamlit-app/src/utils.py
+++ b/streamlit-app/src/utils.py
@@ -9,9 +9,6 @@ import pandas as pd
 import plotly.express as px
 import streamlit as st
 
-from pathlib import Path
-from typing import Literal
-
 
 def resolve_path(path_type: str, relative_path: str = "") -> str:
     """
@@ -53,11 +50,14 @@ def resolve_path(path_type: str, relative_path: str = "") -> str:
 
     raise FileNotFoundError(f"Could not find {path_type} at {relative_path}.")
 
+
 def get_config_path() -> str:
     return resolve_path("config")
 
+
 def get_asset_path(relative_path: str) -> str:
     return resolve_path("asset", relative_path)
+
 
 def show_table(
     name: str, latest_run: str, df: pd.DataFrame, yellow_bound: float, red_bound: float


### PR DESCRIPTION
The visualisation of the Streamlit app happens in 2 different environments:
- We use Docker to run it locally for development
- We use Streamlit Cloud to serve it internally

These 2 environments have different working directories so handling paths to static files was complicated. Namely, the problem was to point to the assets paths and to the configuration yaml.

This PR includes:
- Changes to the Dockerfile so that the app tree emulates the structure of the repo
- Addition of `resolve_path` and `get_asset_path` to search for the resource in different paths depending of the deployment environment
- I have dropped Hydra in the streamlit application: it was causing a lot of problems trying to resolve paths to the yaml, and it was also failing because the app is reactive so it reinitialises Hydra everytime we interact with the app. Effeectively, we were only using Hydra to configure `YELLOW_HIGHLIGHT_BOUND` and `RED_HIGHLIGHT_BOUND`. We're better off now.

These changes work both locally and in Streamlit Cloud, you can test it here https://n9eyhdz2zsgj3ypj3jx6ov.streamlit.app/