### PR TITLE
feat(metrics): update logic for calculating metrics

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,10 +8,9 @@ metric_calculation:
     metrics_root: gs://otar000-evidence_input/release-metrics
 
   datasets:
-    evidence_pre_etl: input/evidence
-    evidence_post_etl: output/evidence
+    evidence_post_etl: output/evidence_*
     evidence_failed: excluded/evidence
-    associations_overall_indirect: output/association_by_overall_indirect
+    associations_overall_indirect: output/association_overall_indirect
     associations_overall_direct: output/association_overall_direct
     associations_source_indirect: output/association_by_datasource_indirect
     associations_source_direct: output/association_by_datasource_direct

--- a/metric-calculation/src/metric_calculation/metrics.py
+++ b/metric-calculation/src/metric_calculation/metrics.py
@@ -21,6 +21,7 @@ from src.metric_calculation.utils import (
     access_gcp_secret,
     initialize_spark_session,
     read_path_if_provided,
+    read_path_with_schema,
     write_metrics_to_csv,
     write_metrics_to_hf_hub,
 )
@@ -302,13 +303,12 @@ def get_columns_to_report(dataset_columns):
         if "diseaseFromSourceMappedId" in dataset_columns
         else "diseaseFromSourceId",
         "drugId",
-        "variantId",
         "literature",
     ]
 
 
 def calculate_additional_post_etl_metrics(metrics_cfg):
-    evidence_failed = read_path_if_provided(
+    evidence_failed = read_path_with_schema(
         f"{metrics_cfg.data_repositories.release_bucket}/{ot_release_bucket}/{metrics_cfg.datasets.evidence_failed}"
     )
     associations_direct = read_path_if_provided(
@@ -366,22 +366,34 @@ def calculate_additional_post_etl_metrics(metrics_cfg):
                 document_total_count(evidence_failed, "evidenceInvalidTotalCount"),
                 # Evidence count (duplicates).
                 document_total_count(
-                    evidence_failed.filter(f.col("markedDuplicate")),
+                    (
+                        evidence_failed
+                        .filter(f.array_contains(f.col("qualityControls"), 'Duplicated'))
+                    ),
                     "evidenceDuplicateTotalCount",
                 ),
                 # Evidence count (nullified score).
                 document_total_count(
-                    evidence_failed.filter(f.col("nullifiedScore")),
+                    (
+                        evidence_failed
+                        .filter(f.array_contains(f.col("qualityControls"), 'No valid score'))
+                    ),
                     "evidenceNullifiedScoreTotalCount",
                 ),
                 # Evidence count (targets not resolved).
                 document_total_count(
-                    evidence_failed.filter(~f.col("resolvedTarget")),
+                    (
+                        evidence_failed
+                        .filter(f.array_contains(f.col("qualityControls"), 'No valid target'))
+                    ),
                     "evidenceUnresolvedTargetTotalCount",
                 ),
                 # Evidence count (diseases not resolved).
                 document_total_count(
-                    evidence_failed.filter(~f.col("resolvedDisease")),
+                    (
+                        evidence_failed
+                        .filter(f.array_contains(f.col("qualityControls"), 'No valid disease'))
+                    ),
                     "evidenceUnresolvedDiseaseTotalCount",
                 ),
                 # Total invalids by datasource.
@@ -390,61 +402,73 @@ def calculate_additional_post_etl_metrics(metrics_cfg):
                 ),
                 # Evidence count by datasource (duplicates).
                 document_count_by(
-                    evidence_failed.filter(f.col("markedDuplicate")),
+                    (
+                        evidence_failed
+                        .filter(f.array_contains(f.col("qualityControls"), 'Duplicated'))
+                    ),
                     "datasourceId",
                     "evidenceDuplicateCountByDatasource",
                 ),
                 # Evidence count by datasource (nullified score).
                 document_count_by(
-                    evidence_failed.filter(f.col("nullifiedScore")),
+                    (
+                        evidence_failed
+                        .filter(f.array_contains(f.col("qualityControls"), 'No valid score'))
+                    ),
                     "datasourceId",
                     "evidenceNullifiedScoreCountByDatasource",
                 ),
                 # Evidence count by datasource (targets not resolved).
                 document_count_by(
-                    evidence_failed.filter(~f.col("resolvedTarget")),
+                    (
+                        evidence_failed
+                        .filter(f.array_contains(f.col("qualityControls"), 'No valid target'))
+                    ),
                     "datasourceId",
                     "evidenceUnresolvedTargetCountByDatasource",
                 ),
                 # Evidence count by datasource (diseases not resolved).
                 document_count_by(
-                    evidence_failed.filter(~f.col("resolvedDisease")),
+                    (
+                        evidence_failed
+                        .filter(f.array_contains(f.col("qualityControls"), 'No valid disease'))
+                    ),
                     "datasourceId",
                     "evidenceUnresolvedDiseaseCountByDatasource",
                 ),
-                # Distinct values in selected fields (total invalid evidence).
-                evidence_distinct_fields_count(
-                    evidence_failed.select(columns_to_report),
-                    "evidenceInvalidDistinctFieldsCountByDatasource",
-                ),
-                # Evidence count by datasource (duplicates).
-                evidence_distinct_fields_count(
-                    evidence_failed.filter(f.col("markedDuplicate")).select(
-                        columns_to_report
-                    ),
-                    "evidenceDuplicateDistinctFieldsCountByDatasource",
-                ),
-                # Evidence count by datasource (nullified score).
-                evidence_distinct_fields_count(
-                    evidence_failed.filter(f.col("nullifiedScore")).select(
-                        columns_to_report
-                    ),
-                    "evidenceNullifiedScoreDistinctFieldsCountByDatasource",
-                ),
-                # Evidence count by datasource (targets not resolved).
-                evidence_distinct_fields_count(
-                    evidence_failed.filter(~f.col("resolvedTarget")).select(
-                        columns_to_report
-                    ),
-                    "evidenceUnresolvedTargetDistinctFieldsCountByDatasource",
-                ),
-                # Evidence count by datasource (diseases not resolved).
-                evidence_distinct_fields_count(
-                    evidence_failed.filter(~f.col("resolvedDisease")).select(
-                        columns_to_report
-                    ),
-                    "evidenceUnresolvedDiseaseDistinctFieldsCountByDatasource",
-                ),
+                # # Distinct values in selected fields (total invalid evidence).
+                # evidence_distinct_fields_count(
+                #     evidence_failed.select(columns_to_report),
+                #     "evidenceInvalidDistinctFieldsCountByDatasource",
+                # ),
+                # # Evidence count by datasource (duplicates).
+                # evidence_distinct_fields_count(
+                #     evidence_failed.filter(f.col("markedDuplicate")).select(
+                #         columns_to_report
+                #     ),
+                #     "evidenceDuplicateDistinctFieldsCountByDatasource",
+                # ),
+                # # Evidence count by datasource (nullified score).
+                # evidence_distinct_fields_count(
+                #     evidence_failed.filter(f.col("nullifiedScore")).select(
+                #         columns_to_report
+                #     ),
+                #     "evidenceNullifiedScoreDistinctFieldsCountByDatasource",
+                # ),
+                # # Evidence count by datasource (targets not resolved).
+                # evidence_distinct_fields_count(
+                #     evidence_failed.filter(~f.col("resolvedTarget")).select(
+                #         columns_to_report
+                #     ),
+                #     "evidenceUnresolvedTargetDistinctFieldsCountByDatasource",
+                # ),
+                # # Evidence count by datasource (diseases not resolved).
+                # evidence_distinct_fields_count(
+                #     evidence_failed.filter(~f.col("resolvedDisease")).select(
+                #         columns_to_report
+                #     ),
+                #     "evidenceUnresolvedDiseaseDistinctFieldsCountByDatasource",
+                # ),
             ]
         )
 

--- a/metric-calculation/src/metric_calculation/utils.py
+++ b/metric-calculation/src/metric_calculation/utils.py
@@ -34,6 +34,29 @@ def initialize_spark_session():
     return SparkSession.builder.getOrCreate()
 
 
+def read_path_with_schema(path: str):
+    """
+    Read the provided path as a Spark dataframe using a specific schema.
+    """
+
+    assert gcsfs.GCSFileSystem().exists(path), (
+        f"The provided path {path} does not exist."
+    )
+
+    schema = t.StructType([
+        t.StructField("id", t.StringType(), True),
+        t.StructField("datasourceId", t.StringType(), True),
+        t.StructField("qualityControls", t.ArrayType(t.StringType()), True)
+    ])
+
+    return (
+        SparkSession.getActiveSession().read
+        .schema(schema)
+        .option("recursiveFileLookup", "true")
+        .parquet(path)
+    )
+
+
 def read_path_if_provided(path: str | None, dir_format="parquet"):
     """
     Automatically detect the format of the input data and read it into the Spark dataframe. The supported formats
@@ -44,9 +67,14 @@ def read_path_if_provided(path: str | None, dir_format="parquet"):
         return None
 
     # The provided path must exist and must be either a file or a directory.
-    assert gcsfs.GCSFileSystem().exists(path), (
-        f"The provided path {path} does not exist."
-    )
+    if "*" in path:
+        assert gcsfs.GCSFileSystem().glob(path), (
+            f"There are no matching files for the provided path {path}."
+        )
+    else:
+        assert gcsfs.GCSFileSystem().exists(path), (
+            f"The provided path {path} does not exist."
+        )
 
     # Case 1: We are provided with a single file.
     if gcsfs.GCSFileSystem().isfile(path):


### PR DESCRIPTION
With the integration of the evidence datasource parsers into pts, we had to update the way we extract metrics from the data.

There is a new `read_path_with_schema` function to read the failed evidence, and the `read_path_if_provided` function has been updated to accomodate paths with `*`.

Given that now we have different schemas for each datasource, not all fields specified in the `get_columns_to_report `function are available for every datasource. As the metrics that depend on this function (ending in `DistinctFieldsCountByDatasource`) are only used in `Explore metrics` but not in `Compare metrics`, they have been commented out for the time being. The metrics calculation is planned to be integrated into pts soon - we will reassess whether we want to keep these fields or drop them later.