### PR TITLE
build: bump urllib3 1.26.6 -> 2.7.0 (off unmaintained 1.26.x)

### DIFF
--- a/metric-calculation/requirements.txt
+++ b/metric-calculation/requirements.txt
@@ -8,6 +8,6 @@ protobuf>=3.20.0
 pyspark>=3.2.0
 furl==2.1.3
 psutil>=5.8.0
-urllib3==1.26.6
+urllib3==2.7.0
 numpy==1.26.4
 scipy==1.14.1


### PR DESCRIPTION
## Summary

Bumps `urllib3` off the unmaintained `1.26.x` line in the metrics pipeline, addressing an outdated-component finding (CWE-1104) from a recent security audit of this repo.

- `metric-calculation/requirements.txt`: `urllib3==1.26.6` → `urllib3==2.7.0`

`urllib3` 1.26.x is no longer maintained per upstream's [v2 migration guide](https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html). This pipeline runs networked batch jobs (GCS, Hugging Face, cloud secrets), so keeping the HTTP/TLS client on a supported release matters. The hard-pin style is kept to match the existing `numpy`/`scipy` pins for reproducible builds.

## Verification

Resolved in a Python 3.12 venv (matching the `python:3.12-bullseye` base image):

- `pip install -r metric-calculation/requirements.txt` resolves with no conflicts; `urllib3` installs at `2.7.0`.
- `pip check` → "No broken requirements found."
- The only runtime `urllib3` constraint in the resolved tree is `requests` (`>=1.26,<3`), satisfied at `requests 2.34.2`. `huggingface-hub`'s `<2.0` cap applies to dev/test extras only (not installed), and `botocore` is not in the tree (the pipeline uses GCS / `google-auth`). Nothing caps `urllib3` back to 1.26.x.

No test suite exists in the repo (CI only builds/pushes Docker images), so dependency resolution is the verification.
