### PR TITLE
fix: correct metric-comparison highlighting and association joins

### DIFF
--- a/app.py
+++ b/app.py
@@ -299,9 +299,14 @@ def main():
                 old_direct_association,
                 new_direct_association,
             ]
-            association = reduce(
-                lambda x, y: pd.merge(x, y, on='datasourceId'), association_datasets
-            ).set_index('datasourceId')
+            association = (
+                reduce(
+                    lambda x, y: pd.merge(x, y, on='datasourceId', how='outer'),
+                    association_datasets,
+                )
+                .set_index('datasourceId')
+                .fillna(0)
+            )
 
             # Compare datasets
             evidence_comparison = compare_entity(
@@ -330,6 +335,7 @@ def main():
                 show_table(
                     name,
                     latest_run,
+                    previous_run,
                     df,
                     YELLOW_HIGHLIGHT_BOUND,
                     RED_HIGHLIGHT_BOUND,

--- a/src/utils.py
+++ b/src/utils.py
@@ -25,7 +25,12 @@ def get_asset_path(relative_path: str = "") -> str:
 
 
 def show_table(
-    name: str, latest_run: str, df: pd.DataFrame, yellow_bound: float, red_bound: float
+    name: str,
+    latest_run: str,
+    previous_run: str,
+    df: pd.DataFrame,
+    yellow_bound: float,
+    red_bound: float,
 ) -> None:
     """Displays the dataframe as a table in the Streamlit app."""
     st.header(f"{name.capitalize()} related metrics")
@@ -36,6 +41,7 @@ def show_table(
             highlight_cell,
             entity=name,
             latest_run=latest_run,
+            previous_run=previous_run,
             yellow_bound=yellow_bound,
             red_bound=red_bound,
             axis=1,
@@ -44,7 +50,12 @@ def show_table(
 
 
 def highlight_cell(
-    row: pd.Series, entity: str, latest_run: str, yellow_bound: float, red_bound: float
+    row: pd.Series,
+    entity: str,
+    latest_run: str,
+    previous_run: str,
+    yellow_bound: float,
+    red_bound: float,
 ) -> list[str]:
     """Highlights the cell in red if the count relative to the total number of evidence is higher than a set threshold.
 
@@ -52,6 +63,7 @@ def highlight_cell(
         row: row of the dataframe
         entity: name of the entity the metrics refer to
         latest_run: latest runId to indicate which column is useful to extract the total number
+        previous_run: previous runId used to compute the delta against the latest run
 
     Returns:
         An array of strings with the css property to pass the Pandas Styler and set the background color.
@@ -73,7 +85,7 @@ def highlight_cell(
             # For diseases, targets and drugs, we have to calculate the delta between releases first
             total_count_diff = (
                 row[f"Nr of {entity} in {latest_run}"]
-                - row[f"Nr of {entity} in {latest_run}"]
+                - row[f"Nr of {entity} in {previous_run}"]
             )
             ratio = abs(total_count_diff / total_count)
         if ratio >= red_bound and ratio != 1:


### PR DESCRIPTION
## Summary

Fixes two pre-existing data-comparison correctness bugs surfaced while reviewing #41. They affect the "Compare metrics" page and ship in the restructured layout introduced by #41, so this PR is **stacked on #41** and targets its head branch as the base.

## Bug 1 (medium): `highlight_cell` delta was always zero

In `src/utils.py`, the diseases/targets/drugs branch computed the delta by subtracting the latest run column from itself:

```python
total_count_diff = (
    row[f"Nr of {entity} in {latest_run}"]
    - row[f"Nr of {entity} in {latest_run}"]   # latest - latest -> always 0
)
```

The ratio was therefore always `0`, so those rows were never highlighted. The second term now references the previous run (`latest - previous`). `previous_run` is threaded through `show_table` -> `highlight_cell`, and the column name (`Nr of {entity} in {previous_run}`) matches how `show_total_between_runs_for_entity` constructs the per-run columns.

## Bug 2 (medium): association comparison used inner joins

In `app.py`, the association datasets (old/new direct/indirect) were merged with the pandas default inner join, silently dropping any datasource present on only one side. This hid added/removed datasources and could produce an empty table if a metric was absent on one side.

The fix mirrors the adjacent evidence comparison: merge with `how='outer'` and `.fillna(0)` after `set_index`, so missing datasources surface (as 0) instead of being dropped. The downstream `add_delta`/`sum` formatting is unchanged and continues to work because the merged values stay numeric.

## Verification

- `python -m py_compile src/utils.py app.py` passes.

Refs #41.
