### PR TITLE
fix: guard run selection in Compare/Explore sidebars

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -340,22 +340,25 @@ def select_and_mask_data_to_compare(all_releases, all_runs, data):
             extract_secondary_run_id_list(all_runs, select_releases),
             help="First indicate the latest run and secondly the run with which you wish to make the comparison. Legend: IDs without a suffix are post-ETL, the latest run belongs to the data in production, 'pre' means pre-ETL and 'ppp' means partner preview platform.",
         )
-        masks_run = (data["runId"] == select_runs[0]) | (
-            data["runId"] == select_runs[1]
-        )
-        filtered_data = data[masks_run]
-        return filtered_data, select_runs
+        if len(select_runs) == 2:
+            masks_run = (data["runId"] == select_runs[0]) | (
+                data["runId"] == select_runs[1]
+            )
+            filtered_data = data[masks_run]
+            return filtered_data, select_runs
+        st.sidebar.info("Please select exactly two runs to compare.")
     return data, []
 
 
 def select_and_mask_data_to_explore(all_releases, all_runs, data):
     st.sidebar.header("What do you want to explore?")
-    select_release = [st.sidebar.selectbox("Select a release:", all_releases)]
+    select_release = st.sidebar.selectbox("Select a release:", all_releases)
 
+    select_run = None
     if select_release != "All":
         select_run = st.sidebar.selectbox(
             "Select a specific release run:",
-            extract_secondary_run_id_list(all_runs, select_release),
+            extract_secondary_run_id_list(all_runs, [select_release]),
             help="Legend: IDs without a suffix are post-ETL, the latest run belongs to the data in production, 'pre' means pre-ETL and 'ppp' means partner preview platform.",
         )
         mask_run = data["runId"] == select_run


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in the Streamlit sidebar selection logic (`src/utils.py`) that were surfaced while reviewing #41. This PR is stacked on top of #41 (base branch `il-deprecate-metrics-calculation`), since the flat file layout (`src/utils.py`, `app.py` at repo root) only exists there.

## Bug 1 (HIGH): Compare page crash — `select_and_mask_data_to_compare`

Once the user selected 1 or 2 releases, the run mask was built unconditionally with `select_runs[0]` / `select_runs[1]`. If the user had not yet picked exactly two runs (`select_runs` is `[]` or length 1), this raised an `IndexError` and crashed the Compare (and Visualise) pages.

Fix: only build the mask and return filtered data when exactly two runs are selected (`len(select_runs) == 2`); otherwise show a `st.sidebar.info(...)` prompt and return the unfiltered data with an empty run list. The `(data, select_runs)` return contract is preserved — callers in `app.py` guard with `if selected_runs:` before unpacking `latest_run, previous_run = selected_runs`.

## Bug 2 (MEDIUM): Explore selection fragility — `select_and_mask_data_to_explore`

`select_release = [st.sidebar.selectbox(...)]` wrapped the single selection in a list, so `if select_release != "All":` compared a list to a string and was **always** true. It only worked because that branch is the sole place `select_run` is assigned — had the branch ever evaluated false, `return data, select_run` would have raised `NameError`. Note "All" is in fact a valid option (`extract_primary_run_id_list` prepends it).

Fix: use a scalar `select_release`, initialize `select_run = None` before the branch so it is always defined, and pass `[select_release]` only where `extract_secondary_run_id_list` requires a list. When "All" is selected, `select_run` is `None` and `app.py`'s `if selected_run:` guard correctly skips the per-run views.

## Verification

`python -m py_compile src/utils.py app.py` passes.

Refs #41.
